### PR TITLE
Use IPv6-enabled NIST pool

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -1,7 +1,7 @@
 #include "ntp-client/NTPClient.h"
 #include "mbed.h"
 
-const char* NTPClient::NIST_SERVER_ADDRESS = "pool.ntp.org";
+const char* NTPClient::NIST_SERVER_ADDRESS = "2.pool.ntp.org";
 const int NTPClient::NIST_SERVER_PORT = 123;
 
 NTPClient::NTPClient(NetworkInterface *iface) {


### PR DESCRIPTION
Fixing issue #1 
This allows the use of NTP by Thread nodes (i.e. mbed client)