### PR TITLE
Ability to provide network later

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -1,11 +1,11 @@
 #include "ntp-client/NTPClient.h"
 #include "mbed.h"
 
-NTPClient::NTPClient(NetworkInterface *iface)
-: iface(iface), nist_server_address((char *)NTP_DEFULT_NIST_SERVER_ADDRESS), nist_server_port(NTP_DEFULT_NIST_SERVER_PORT) {
+NTPClient::NTPClient(NetworkInterface *interface)
+    : iface(interface), nist_server_address((char *)NTP_DEFULT_NIST_SERVER_ADDRESS), nist_server_port(NTP_DEFULT_NIST_SERVER_PORT) {
 }
 
-void NTPClient::set_server(char* server, int port){
+void NTPClient::set_server(char* server, int port) {
     nist_server_address = server;
     nist_server_port = port;
 }
@@ -16,40 +16,53 @@ time_t NTPClient::get_timestamp(int timeout) {
     int ntp_recv_values[12] = {0};
 
     SocketAddress nist;
-    int ret_gethostbyname = iface->gethostbyname(nist_server_address, &nist);
 
-    if (ret_gethostbyname < 0) {
-        // Network error on DNS lookup
-        return ret_gethostbyname;
-    }
+    if (iface) {
+        int ret_gethostbyname = iface->gethostbyname(nist_server_address, &nist);
 
-    nist.set_port(nist_server_port);
-
-    memset(ntp_send_values, 0x00, sizeof(ntp_send_values));
-    ntp_send_values[0] = '\x1b';
-
-    memset(ntp_recv_values, 0x00, sizeof(ntp_recv_values));
-
-    UDPSocket sock;
-    sock.open(iface);
-    sock.set_timeout(timeout);
-
-    sock.sendto(nist, (void*)ntp_send_values, sizeof(ntp_send_values));
-
-    SocketAddress source;
-    const int n = sock.recvfrom(&source, (void*)ntp_recv_values, sizeof(ntp_recv_values));
-
-    if (n > 10) {
-        return ntohl(ntp_recv_values[10]) - TIME1970;
-    } else {
-        if (n < 0) {
-            // Network error
-            return n;
-        } else {
-            // No or partial data returned
-            return -1;
+        if (ret_gethostbyname < 0) {
+            // Network error on DNS lookup
+            return ret_gethostbyname;
         }
+
+        nist.set_port(nist_server_port);
+
+        memset(ntp_send_values, 0x00, sizeof(ntp_send_values));
+        ntp_send_values[0] = '\x1b';
+
+        memset(ntp_recv_values, 0x00, sizeof(ntp_recv_values));
+
+        UDPSocket sock;
+        sock.open(iface);
+        sock.set_timeout(timeout);
+
+        sock.sendto(nist, (void*)ntp_send_values, sizeof(ntp_send_values));
+
+        SocketAddress source;
+        const int n = sock.recvfrom(&source, (void*)ntp_recv_values, sizeof(ntp_recv_values));
+
+        if (n > 10) {
+            return ntohl(ntp_recv_values[10]) - TIME1970;
+
+        } else {
+            if (n < 0) {
+                // Network error
+                return n;
+
+            } else {
+                // No or partial data returned
+                return -1;
+            }
+        }
+
+    } else {
+        // No network interface
+        return -2;
     }
+}
+
+void NTPClient::network(NetworkInterface *interface) {
+    iface = interface;
 }
 
 uint32_t NTPClient::ntohl(uint32_t x) {

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -5,9 +5,10 @@
 
 class NTPClient {
     public:
-        NTPClient(NetworkInterface *iface);
+        explicit NTPClient(NetworkInterface *interface = NULL);
         void set_server(char* server, int port);
         time_t get_timestamp(int timeout = 15000);
+        void network(NetworkInterface *interface);
 
     private:
         NetworkInterface *iface;


### PR DESCRIPTION
If using latest OS you are unable to create global object with NetworkInterface argument, but you can pass it later with ie. `CellularDevice::get_default_instance()`