### PR TITLE
Change get_timestamp() return type to int64_t to support ARMCC

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -26,7 +26,7 @@ void NTPClient::set_server(const char* server, int port) {
     nist_server_port = port;
 }
 
-time_t NTPClient::get_timestamp(int timeout) {
+int64_t NTPClient::get_timestamp(int timeout) {
     const time_t TIME1970 = (time_t)2208988800UL;
     int ntp_send_values[12] = {0};
     int ntp_recv_values[12] = {0};

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -23,7 +23,7 @@ class NTPClient {
     public:
         explicit NTPClient(NetworkInterface *interface = NULL);
         void set_server(const char* server, int port);
-        time_t get_timestamp(int timeout = 15000);
+        int64_t get_timestamp(int timeout = 15000);
         void network(NetworkInterface *interface);
 
     private:


### PR DESCRIPTION
`time_t NTPClient::get_timestamp()` returns negative values on errors, which is fine with GCC_ARM whose `time_t` is 64-bit integer. But the Arm Compiler's `time_t` is 32-bit unsigned integer, in `ac6/include/time.h`:
```c
typedef unsigned int time_t;     /* date/time in unix secs past 1-Jan-70 */
```

When an error is reported, the value that gets returned with ARMCC is something like year 2100 and the caller cannot catch it.

To resolve this, change the return type of `NTPClient::get_timestamp()` to `int64_t`.
Note: This is a **breaking change** for applications compiled with the Arm Compiler. Callers should store the return value to a 64-bit integer, check the value, then cast it to `time_t`.