### PR TITLE
CMake: Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(ntp-client INTERFACE)
+
+target_include_directories(ntp-client
+    INTERFACE
+        .
+)
+
+target_sources(ntp-client
+    INTERFACE
+        NTPClient.cpp
+)
+
+target_link_libraries(ntp-client
+    INTERFACE
+        mbed-netsocket
+)


### PR DESCRIPTION
- Added CMakeLists.txt file to ntp-client so that it can able build via CMake

@0xc0170 @hugueskamba 