### PR TITLE
New get_timestamp() API that separates error code and time value

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -15,6 +15,7 @@
  */
 
 #include "mbed.h"
+#include "platform/mbed_toolchain.h"
 
 #define NTP_DEFULT_NIST_SERVER_ADDRESS "2.pool.ntp.org"
 #define NTP_DEFULT_NIST_SERVER_PORT 123
@@ -22,8 +23,16 @@
 class NTPClient {
     public:
         explicit NTPClient(NetworkInterface *interface = NULL);
+
         void set_server(const char* server, int port);
+
+        int get_timestamp(time_t &timestamp, int timeout = 15000);
+
+        MBED_DEPRECATED(
+            "This cannot return negative error codes with ARM toolchain's unsigned time_t. "
+            "Please use int get_timestamp(time_t &timestamp, int timeout) instead")
         time_t get_timestamp(int timeout = 15000);
+
         void network(NetworkInterface *interface);
 
     private:


### PR DESCRIPTION
Replaces #12 

The ARM toolchain's time_t is unsigned, so we can't return a negative time_t to indicate an error - it gets casted to a very large positive time.

This commit adds a new overload
```cpp
  int NTPClient::get_timestamp(time_t &timestamp, int timeout);
```
which returns 0 on success and a negative value on failure. On success, the time is written to the timestamp variable. This deprecates the old NTPClient::get_timestamp().

Note: The NTPClient is used by cloud connector examples (e.g. [mbed-os-example-for-azure](https://github.com/ARMmbed/mbed-os-example-for-azure)), and we have no way to catch NTP errors and retry when using the Arm Compiler due to the error being addressed here. We improved NTP stability by using `time.google.com`, but even that one seems to time out occasionally.