### PR TITLE
Fix include path

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "ntp-client/NTPClient.h"
+#include "NTPClient.h"
 #include "mbed.h"
 
 NTPClient::NTPClient(NetworkInterface *interface)


### PR DESCRIPTION
When building with CMake, the include define did not correspond to the include directory provided to CMake.